### PR TITLE
feat: allow tree-shaking with esm and side effects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "nbt-ts",
       "version": "1.3.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.4.8",
-        "typescript": "^4.3.5"
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@types/node": {
@@ -19,9 +20,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -40,9 +41,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,17 @@
   "name": "nbt-ts",
   "version": "1.3.4",
   "description": "An easy to use encoder and decoder for the NBT format",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/janispritzkau/nbt-ts.git"
   },
   "scripts": {
     "test": "node test",
-    "prepare": "tsc && npm run test"
+    "build": "tsc && tsc --module esnext --outDir lib/esm",
+    "prepare": "npm run build && npm run test"
   },
   "keywords": [
     "nbt",
@@ -22,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^16.4.8",
-    "typescript": "^4.3.5"
-  }
+    "typescript": "^4.7.4"
+  },
+  "sideEffects": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "module": "commonjs",
         "strict": true,
         "lib": ["esnext"],
-        "outDir": "lib",
+        "outDir": "lib/cjs",
+        "moduleResolution": "node",
         "declaration": true
     },
     "include": [


### PR DESCRIPTION
This PR adds esm output alongside the current commonjs output, allowing modern bundlers and tooling to tree shake the output source code. Setting of sideEffects to false in the package.json also tells webpack and other bundlers that the package doesn't contain side effects, allowing some optimisations to work better.

I also updated TypeScript, as newer versions have much better esm output support

While this is a small library, this would allow the entire snbt system to be stripped when only NBT decoding is used, for example.