### PR TITLE
feat: make SNBT compatible with boolean values

### DIFF
--- a/examples/snbt.ts
+++ b/examples/snbt.ts
@@ -5,8 +5,13 @@ console.log(stringify({ json: `{"text":"Hello"}` }))
 console.log(stringify({ $: `Hellow` }))
 
 console.log(stringify({
+    str: { a: "true", b: "false" },
+    bool: { a: true, b: false }
+}))
+
+console.log(stringify({
     a: [1/4, 1 / 3],
     b: new Int32Array(8)
 }, { quote: "single", pretty: true }))
 
-console.log(parse(`{id:"minecraft:diamond_sword",Count:1b,tag:{ench:[{lvl:5s,id:16s},{lvl:3s,id:21s}],RepairCost:6,display:{Name:"Resilience"}},Damage:0s}`))
+console.log(parse(`{id:"minecraft:diamond_sword",Count:1b,tag:{ench:[{lvl:5s,id:16s},{lvl:3s,id:21s}],RepairCost:6,display:{Name:"Resilience"},Unbreakable:true},Damage:0s}`))

--- a/src/snbt.ts
+++ b/src/snbt.ts
@@ -31,6 +31,7 @@ export function stringify(tag: nbt.Tag, options: StringifyOptions = {}): string 
     function stringify(tag: nbt.Tag, depth: number): string {
         const space = pretty ? " " : "", sep = pretty ? ", " : ","
         if (tag instanceof nbt.Byte) return `${tag.value}b`
+        else if (typeof tag == "boolean") return `${tag ? 1 : 0}b`
         else if (tag instanceof nbt.Short) return `${tag.value}s`
         else if (tag instanceof nbt.Int) return `${tag.value | 0}`
         else if (typeof tag == "bigint") return `${tag}l`
@@ -229,7 +230,11 @@ export function parse(text: string, options: ParseOptions = {}) {
         if (value != null && (index == text.length || !unquotedRegExp.test(text[index]))) {
             return value
         }
-        return text.slice(i, index) + readUnquotedString()
+        const unquotedString = text.slice(i, index) + readUnquotedString()
+        if (unquotedString.toLowerCase() == "true" || unquotedString.toLowerCase() == "false") {
+            return new nbt.Byte(unquotedString == "true" ? 1 : 0)
+        }
+        return unquotedString
     }
 
     const value = parse()

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -38,11 +38,12 @@ export interface TagArray extends Array<Tag> { }
 export interface TagObject { [key: string]: Tag | undefined | null }
 export interface TagMap extends Map<string, Tag> { }
 
-export type Tag = number | string | bigint | Byte | Short | Int | Float | Buffer
+export type Tag = number | string | bigint | boolean | Byte | Short | Int | Float | Buffer
     | Int8Array | Int32Array | BigInt64Array | TagArray | TagObject | TagMap
 
 export function getTagType(tag: Tag): TagType {
     if (tag instanceof Byte) return TagType.Byte
+    if (typeof tag == "boolean") return TagType.Byte
     if (tag instanceof Short) return TagType.Short
     if (tag instanceof Int) return TagType.Int
     if (typeof tag == "bigint") return TagType.Long


### PR DESCRIPTION
This PR adds support for booleans in SNBT.
In Minecraft, unquoted `true` and `false` are recognized as ByteTags.

![image](https://user-images.githubusercontent.com/25514849/233155381-9f497ca5-fffb-4e3e-ab04-f214a35fa3d4.png)
![image](https://user-images.githubusercontent.com/25514849/233155569-bfc38079-f2e3-4259-ae61-e2fddb8b0748.png)

```ts
console.log(parse(`{a:true,b:false,c:"true",d:"false"}`))

// current
// { a: 'true', b: 'false', c: 'true', d: 'false' }

// this PR
// { a: Byte { value: 1 }, b: Byte { value: 0 }, c: 'true', d: 'false' }
```